### PR TITLE
Explain request time

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@ every request to an InfluxDB backend exposing UDP.
 
 ## Exported Fields (per request)
 
-| Metric                | Type    | Description                                                                                                                               |
-|-----------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| method                | string  | The HTTP request method that has been given as a reply to the caller                                                                      |
-| status                | integer | The HTTP status code of the reply from the server (refer to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-6.1) for more details) |
-| bytes_sent            | integer | The number of bytes sent to a client body + header                                                                                        |
-| body_bytes_sent       | integer | The number of bytes sent to a client only for body                                                                                        |
-| header_bytes_sent     | integer | The number of bytes sent to a client for header and body                                                                                  |
-| request_length        | integer | Request length (including request line, header, and request body)                                                                         |
-| uri                   | string  | The called uri (e.g: /index.html)                                                                                                         |
-| extension             | string  | The extension of the served file (e.g: js, html, php, png)                                                                                |
-| content_type          | string  | The content type of the response (e.g: text/html)                                                                                         |
+| Metric                | Type    | Description                                                                                                                                                                                           |
+|-----------------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| method                | string  | The HTTP request method that has been given as a reply to the caller                                                                                                                                  |
+| status                | integer | The HTTP status code of the reply from the server (refer to [RFC 7231](https://tools.ietf.org/html/rfc7231#section-6.1) for more details)                                                             |
+| bytes_sent            | integer | The number of bytes sent to a client body + header                                                                                                                                                    |
+| body_bytes_sent       | integer | The number of bytes sent to a client only for body                                                                                                                                                    |
+| header_bytes_sent     | integer | The number of bytes sent to a client for header and body                                                                                                                                              |
+| request_length        | integer | Request length (including request line, header, and request body)                                                                                                                                     |
+| uri                   | string  | The called uri (e.g: /index.html)                                                                                                                                                                     |
+| extension             | string  | The extension of the served file (e.g: js, html, php, png)                                                                                                                                            |
+| content_type          | string  | The content type of the response (e.g: text/html)                                                                                                                                                     |
+| request_time          | string  | Request processing time in seconds with a milliseconds resolution                                                                                                                                     |
 
 
 ## Installation


### PR DESCRIPTION
The new field has been added with #5 and can be used to show latency graphs in Mbit/s, it is in seconds with a millisecond resolution.

![image](https://user-images.githubusercontent.com/3083633/40960922-70f53c64-68a1-11e8-9ff8-3f5110f4af02.png)
![image](https://user-images.githubusercontent.com/3083633/40988614-d434a0c2-68eb-11e8-85b1-000bc5e36e4d.png)


The query is:

```
SELECT non_negative_derivative(sum("request_length"), 1s) * 8 AS "sum_request_length" FROM "mydb"."myretention"."nginx" WHERE time > :dashboardTime: GROUP BY time(:interval:) FILL(null)
```

Signed-off-by: Lorenzo Fontana <lo@linux.com>