### PR TITLE
Fix compilation error with GCC 5.0

### DIFF
--- a/src/ngx_http_influxdb.c
+++ b/src/ngx_http_influxdb.c
@@ -58,7 +58,7 @@ static ngx_int_t ngx_http_influxdb_handler(ngx_http_request_t *req) {
   ngx_http_influxdb_loc_conf_t *conf;
   conf = ngx_http_get_module_loc_conf(req, ngx_http_influxdb_module);
 
-  if (!ngx_strcmp(conf->enabled.data, "true") == 0) {
+  if (!(ngx_strcmp(conf->enabled.data, "true") == 0)) {
     return NGX_OK;
   }
 


### PR DESCRIPTION
Error output before fix:
```
In ngx_http_influxdb.c:61:7:error: logical not is only applied to the left hand side of this comparison
```