### PR TITLE
Fixed build error with nginx >= 1.23.0

### DIFF
--- a/src/ngx_http_influxdb_metric.c
+++ b/src/ngx_http_influxdb_metric.c
@@ -1,3 +1,5 @@
+#include "ngx_http_influxdb_metric.h"
+
 #include <arpa/inet.h>
 #include <inttypes.h>
 #include <netinet/in.h>
@@ -8,8 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
-
-#include "ngx_http_influxdb_metric.h"
 
 static ngx_buf_t *create_temp_char_buf(ngx_pool_t *pool, size_t size) {
   ngx_buf_t *b;


### PR DESCRIPTION
In file included from src/event/ngx_event.h:565:0,
                 from src/http/ngx_http_upstream.h:14,
                 from src/http/ngx_http.h:37,
                 from /tmp/build/nginx-influxdb-module-/src/ngx_http_influxdb_metric.c:7:
                 src/event/ngx_event_udp.h:38:27: error: field 'pkt6' has incomplete type
                 struct in6_pktinfo    pkt6;

The issue is caused by nginx-influxdb-module including system headers prior to nginx ones.
In this particular case, it leads to undefined GNU_SOURCE macro and thus missing type declaration.